### PR TITLE
- patch fixes broken compilation of mod_gss version 1.3.8 with proftpd

### DIFF
--- a/mod_gss/mod_gss/mod_gss.c.in
+++ b/mod_gss/mod_gss/mod_gss.c.in
@@ -844,7 +844,7 @@ MODRET gss_authenticate(cmd_rec *cmd) {
             }
         } else {
            gss_log("GSSAPI User %s/%s authorized by kdc.",cmd->argv[0],client_name.value? (char *) client_name.value:"-");
-	   return HANDLED(cmd);
+	   return PR_HANDLED(cmd);
         }
     }
     gss_log("GSSAPI User %s is not authorized. Use other methods to authenticate.", cmd->argv[0]);
@@ -1057,7 +1057,7 @@ MODRET gss_auth_check(cmd_rec *cmd) {
             }
         } else {
            gss_log("GSSAPI User %s/%s authorized by kdc.",cmd->argv[1],client_name.value? (char *) client_name.value:"-");
-	   return HANDLED(cmd);
+	   return PR_HANDLED(cmd);
         }
     }
     gss_log("GSSAPI User %s is not authorized. Use other methods to authenticate.", cmd->argv[1]);
@@ -1081,18 +1081,18 @@ MODRET gss_ccc(cmd_rec *cmd) {
     } else if (!(gss_flags & GSS_SESS_ADAT_OK)) {
         pr_response_add_err(R_503, "Security data exchange not completed");
         gss_log("GSSAPI security data exchange not completed before %s command",cmd->argv[0]);
-        return ERROR(cmd);
+        return PR_ERROR(cmd);
     }
  
     if (gss_opts & GSS_OPT_ALLOW_CCC){
         gss_flags |= GSS_SESS_CCC;
         pr_response_add(R_200, "CCC command successful");
-        return HANDLED(cmd);
+        return PR_HANDLED(cmd);
     }
 
     pr_response_add_err(R_534, mesg);
     gss_log("GSSAPI %s", mesg);
-    return ERROR(cmd);
+    return PR_ERROR(cmd);
 
 }
 
@@ -1109,7 +1109,7 @@ MODRET gss_fwccc(cmd_rec *cmd) {
     } else if (!(gss_flags & GSS_SESS_ADAT_OK)) {
         pr_response_add_err(R_503, "Security data exchange not completed");
         gss_log("GSSAPI security data exchange not completed before %s command",cmd->argv[0]);
-        return ERROR(cmd);
+        return PR_ERROR(cmd);
     }
 
     if (gss_opts & GSS_OPT_ALLOW_FW_CCC){
@@ -1118,12 +1118,12 @@ MODRET gss_fwccc(cmd_rec *cmd) {
         else
            gss_flags |= GSS_SESS_FWCCC;
         pr_response_add(R_200, "FWCCC command successfully switched %s",gss_flags & GSS_SESS_FWCCC ? "On":"Off");
-        return HANDLED(cmd);
+        return PR_HANDLED(cmd);
     }
 
     pr_response_add_err(R_534, mesg);
     gss_log("GSSAPI %s", mesg);
-    return ERROR(cmd);
+    return PR_ERROR(cmd);
 
 }
 
@@ -1166,7 +1166,7 @@ MODRET gss_dec(cmd_rec *cmd) {
     } else if (!(gss_flags & GSS_SESS_ADAT_OK)) {
         pr_response_add_err(R_503, "Security data exchange not completed");
         gss_log("GSSAPI security data exchange not completed before %s command",cmd->argv[0]);
-        return ERROR(cmd);
+        return PR_ERROR(cmd);
     }
 
     if ( ! strcmp(cmd->argv[0], "CONF") ) {
@@ -1175,7 +1175,7 @@ MODRET gss_dec(cmd_rec *cmd) {
 /*
   session.sp_flags = SP_CONF;
 */
-        return ERROR(cmd);
+        return PR_ERROR(cmd);
     } else if ( ! strcmp(cmd->argv[0], "ENC") && (gss_flags & GSS_SESS_CONF_SUP)) { 
         session.sp_flags = SP_ENC;
 	conf_state = 1;
@@ -1185,7 +1185,7 @@ MODRET gss_dec(cmd_rec *cmd) {
     } else {
         pr_response_add_err(R_536,"Protection level %s not supported.",cmd->argv[0]);
         gss_log("GSSAPI Protection level %s not supported.",cmd->argv[0]);
-        return ERROR(cmd);
+        return PR_ERROR(cmd);
     }
 
     /* remove trailing \r \n */
@@ -1203,7 +1203,7 @@ MODRET gss_dec(cmd_rec *cmd) {
 	gss_log("GSSAPI Can't base 64 decode argument to %s command (%s)",
 		session.sp_flags & SP_ENC ? "ENC" : 
                 session.sp_flags & SP_MIC ? "MIC" : "", radix_error(error));
-        return ERROR(cmd);
+        return PR_ERROR(cmd);
     }
 
     /* decrypt the message */
@@ -1223,7 +1223,7 @@ MODRET gss_dec(cmd_rec *cmd) {
                        session.sp_flags & SP_MIC ? 
 		       "failed unsealing/unwraping MIC message":
                        "failed unsealing/unwraping message");
-        return ERROR(cmd);
+        return PR_ERROR(cmd);
     }
     
     dec_buf=pcalloc(cmd->pool, msg_buf.length+1);
@@ -1245,11 +1245,11 @@ MODRET gss_dec(cmd_rec *cmd) {
         gss_flags &= ~GSS_SESS_DISPATCH;
       	pr_response_add_err(R_535,"command %s rejected",dec_buf);
         gss_log("GSSAPI Failed dispatching command %s",dec_buf);
-        return ERROR(cmd);
+        return PR_ERROR(cmd);
     }
     gss_flags &= ~GSS_SESS_DISPATCH;
 
-    return HANDLED(cmd);
+    return PR_HANDLED(cmd);
 }
 
 MODRET gss_any(cmd_rec *cmd) {
@@ -1298,7 +1298,7 @@ MODRET gss_any(cmd_rec *cmd) {
     if ( gss_required_on_ctrl ) {
 	pr_response_add_err(R_550, "GSS protection required on control channel");
 	gss_log("GSSAPI GSS protection required on control channel");
-	return ERROR(cmd);
+	return PR_ERROR(cmd);
     }
 
     /* After ADAT all commands have to be protected by ENC/MIC/CONF */
@@ -1306,7 +1306,7 @@ MODRET gss_any(cmd_rec *cmd) {
         session.sp_flags = SP_CCC; 
 	pr_response_add_err(R_533, "All commands must be protected.");
 	gss_log("GSSAPI Unprotected command(%s) received",cmd->argv[0]);
-	return ERROR(cmd);
+	return PR_ERROR(cmd);
     }
 
     return PR_DECLINED(cmd);
@@ -1367,6 +1367,7 @@ MODRET gss_any(cmd_rec *cmd) {
 MODRET gss_auth(cmd_rec *cmd) {
     unsigned int i = 0;
     OM_uint32 maj_stat, min_stat;
+    char **argv = (char **)cmd->argv;
 
     if (!gss_engine)
 	return PR_DECLINED(cmd);
@@ -1394,24 +1395,24 @@ MODRET gss_auth(cmd_rec *cmd) {
     }
     
     /* Convert the parameter to upper case */
-    for (i = 0; i < strlen(cmd->argv[1]); i++)
-	(cmd->argv[1])[i] = toupper((cmd->argv[1])[i]);
+    for (i = 0; i < strlen(argv[1]); i++)
+	argv[1][i] = toupper(argv[1][i]);
 
-    if (!strcmp(cmd->argv[1], "GSSAPI")) { 
-	pr_response_send(R_334, "Using authentication type %s; ADAT must follow", cmd->argv[1]);
+    if (!strcmp(argv[1], "GSSAPI")) { 
+	pr_response_send(R_334, "Using authentication type %s; ADAT must follow", argv[1]);
 	gss_log("GSSAPI Auth GSSAPI requested, ADAT must follow");
 	gss_flags |= GSS_SESS_AUTH_OK;
     } else {
 /*
-  pr_response_add_err(R_504, "AUTH %s unsupported", cmd->argv[1]);
-  return ERROR(cmd);
+  pr_response_add_err(R_504, "AUTH %s unsupported", argv[1]);
+  return PR_ERROR(cmd);
 */
         gss_flags &= ~GSS_SESS_AUTH_OK;
         return PR_DECLINED(cmd);
     }
 
     session.rfc2228_mech = "GSSAPI";
-    return HANDLED(cmd);
+    return PR_HANDLED(cmd);
 }
 
 /*
@@ -1552,7 +1553,7 @@ MODRET gss_adat(cmd_rec *cmd) {
     } else if (!(gss_flags & GSS_SESS_AUTH_OK)) {
 	pr_response_add_err(R_503, "You must issue the AUTH command prior to ADAT");
         gss_log("GSSAPI You must issue the AUTH command prior to ADAT");
-        return ERROR(cmd); 
+        return PR_ERROR(cmd); 
     }
   
     /* Use cmd->arg instead of cmd->argv[1]
@@ -1569,14 +1570,14 @@ MODRET gss_adat(cmd_rec *cmd) {
     if ((error = radix_encode((unsigned char*)cmd->arg, tok.value , (int *)&tok.length, 1)) !=0  ) {
 	pr_response_add_err(R_501, "Couldn't decode ADAT (%s)",radix_error(error)); 
 	gss_log("GSSAPI Could not decode ADAT (%s)",radix_error(error));
-	return ERROR(cmd);
+	return PR_ERROR(cmd);
     }
 
     rev = pr_netaddr_set_reverse_dns(TRUE);
     if (strlen(pr_netaddr_get_dnsstr(session.c->local_addr)) > MAXHOSTNAMELEN -1 ) {
 	gss_log("GSSAPI Hostname (%s) longer then MAXHOSTNAMELEN:%d",pr_netaddr_get_dnsstr(session.c->local_addr),MAXHOSTNAMELEN);
         pr_response_add_err(R_535, "Internal error"); 
-	return ERROR(cmd);
+	return PR_ERROR(cmd);
     }
     strcpy(localname,pr_netaddr_get_dnsstr(session.c->local_addr));
     pr_netaddr_set_reverse_dns(rev);
@@ -1746,7 +1747,7 @@ MODRET gss_adat(cmd_rec *cmd) {
         session.sp_flags = 0;
 
         gss_switch_keytab(env_keytab_file,0);
-        return HANDLED(cmd);
+        return PR_HANDLED(cmd);
     } else if (maj_stat == GSS_S_CONTINUE_NEEDED) {
 	/* If the server accepts the security data, and
 	   requires additional data, it should respond with
@@ -1756,7 +1757,7 @@ MODRET gss_adat(cmd_rec *cmd) {
         gss_release_cred(&acquire_min, &server_creds);
 	gss_release_name(&min_stat, &server);
         gss_switch_keytab(env_keytab_file,0);
-	return HANDLED(cmd);
+	return PR_HANDLED(cmd);
     } else {
 	/* "If the server rejects the security data (if
 	   a checksum fails, for instance), it should
@@ -1769,7 +1770,7 @@ MODRET gss_adat(cmd_rec *cmd) {
     }
 err:
     gss_switch_keytab(env_keytab_file,0);
-    return ERROR(cmd);
+    return PR_ERROR(cmd);
 }
 
 /*
@@ -1803,6 +1804,7 @@ err:
 
  */
 MODRET gss_pbsz(cmd_rec *cmd) {
+    char **argv = (char **)cmd->argv;
 
     if (!gss_engine)
 	return PR_DECLINED(cmd);
@@ -1814,20 +1816,20 @@ MODRET gss_pbsz(cmd_rec *cmd) {
     } else if (!(gss_flags & GSS_SESS_ADAT_OK)) {
 	pr_response_add_err(R_503, "PBSZ not allowed on insecure control connection");
         gss_log("GSSAPI PBSZ not allowed on insecure control connection");
-	return ERROR(cmd);
+	return PR_ERROR(cmd);
     }
 
 
-    if (strlen(cmd->argv[1]) > 10 ||
-	( strlen(cmd->argv[1]) == 10 && strcmp(cmd->argv[1],"4294967296") >= 0 )) {
-	pr_response_add_err(R_501, "Bad value for PBSZ: %s", cmd->argv[1]);
-	gss_log("GSSAPI Bad value for PBSZ: %s", cmd->argv[1]);
-	return ERROR(cmd);
-    } else if (actualbuf >= (maxbuf =(unsigned int) atol(cmd->argv[1]))) {
+    if (strlen(argv[1]) > 10 ||
+	( strlen(argv[1]) == 10 && strcmp(argv[1],"4294967296") >= 0 )) {
+	pr_response_add_err(R_501, "Bad value for PBSZ: %s", argv[1]);
+	gss_log("GSSAPI Bad value for PBSZ: %s", argv[1]);
+	return PR_ERROR(cmd);
+    } else if (actualbuf >= (maxbuf =(unsigned int) atol(argv[1]))) {
 	pr_response_send(R_200, "PBSZ=%u", actualbuf);
 	gss_log("GSSAPI Set PBSZ=%u", actualbuf);
     } else {
-	actualbuf = (unsigned int) atol(cmd->argv[1]);
+	actualbuf = (unsigned int) atol(argv[1]);
 	/* I attempt what is asked for first, and if that
 	   fails, I try dividing by 4 */
 	while ((ucbuf = (unsigned char *)pcalloc(session.pool ? session.pool : permanent_pool, actualbuf)) == NULL) {
@@ -1837,7 +1839,7 @@ MODRET gss_pbsz(cmd_rec *cmd) {
 	    } else {
 		pr_response_add_err(R_421, "Local resource failure: pcalloc");
 		gss_log("GSSAPI Local resource failure: pcalloc");
-		return ERROR(cmd);
+		return PR_ERROR(cmd);
 	    }
 	}
 	pr_response_send(R_200, "PBSZ=%u", maxbuf = actualbuf);
@@ -1845,7 +1847,7 @@ MODRET gss_pbsz(cmd_rec *cmd) {
     }
 
     gss_flags |= GSS_SESS_PBSZ_OK;
-    return HANDLED(cmd);
+    return PR_HANDLED(cmd);
 }
 
 /*
@@ -2001,6 +2003,7 @@ MODRET gss_pbsz(cmd_rec *cmd) {
  */
 MODRET gss_prot(cmd_rec *cmd) {
     int i;
+    char **argv = (char **)cmd->argv;
 
     if (!gss_engine)
 	return PR_DECLINED(cmd);
@@ -2012,15 +2015,15 @@ MODRET gss_prot(cmd_rec *cmd) {
     } else if (!(gss_flags & GSS_SESS_PBSZ_OK)) {
    	pr_response_add_err(R_503, "You must issue the PBSZ command prior to PROT");
         gss_log("GSSAPI You must issue the PBSZ command prior to PROT");
-	return ERROR(cmd);
+	return PR_ERROR(cmd);
     }
 
     /* Convert the parameter to upper case */
-    for (i = 0; i < strlen(cmd->argv[1]); i++)
-	(cmd->argv[1])[i] = toupper((cmd->argv[1])[i]);
+    for (i = 0; i < strlen(argv[1]); i++)
+	argv[1][i] = toupper(argv[1][i]);
 
     /* Only PROT S , PROT C or PROT P is valid with respect to GSS. */
-    if (!strcmp(cmd->argv[1], "C")) {
+    if (!strcmp(argv[1], "C")) {
 	char *mesg = "Protection set to Clear";
 
 	if (!gss_required_on_data) {
@@ -2035,39 +2038,39 @@ MODRET gss_prot(cmd_rec *cmd) {
 	} else {
 	    pr_response_add_err(R_534, "Unwilling to accept security parameters");
             gss_log("GSSAPI Unwilling to accept security parameters");
-	    return ERROR(cmd);
+	    return PR_ERROR(cmd);
 	}
 
-    } else if (!strcmp(cmd->argv[1], "P") && (gss_flags & GSS_SESS_CONF_SUP)) {
+    } else if (!strcmp(argv[1], "P") && (gss_flags & GSS_SESS_CONF_SUP)) {
 	char *mesg = "Protection set to Private";
 
 	gss_prot_flags = GSS_SESS_PROT_P;
 	pr_response_add(R_200, "%s", mesg);
 	gss_log("GSSAPI %s", mesg);
 
-    } else if (!strcmp(cmd->argv[1], "S") && (gss_flags & GSS_SESS_INT_SUP)) {
+    } else if (!strcmp(argv[1], "S") && (gss_flags & GSS_SESS_INT_SUP)) {
 	char *mesg = "Protection set to Safe";
 
 	gss_prot_flags = GSS_SESS_PROT_S;
 	pr_response_add(R_200, "%s", mesg);
 	gss_log("GSSAPI %s", mesg);
 
-    } else if (!strcmp(cmd->argv[1], "E"))  {
+    } else if (!strcmp(argv[1], "E"))  {
 	char *mesg = "Protection NOT set to Confidential";
 	gss_prot_flags = GSS_SESS_PROT_E;
 	pr_response_add_err(R_536, "PROT E (Confidential) unsupported");
 	gss_log("GSSAPI %s", mesg);
-	return ERROR(cmd);
+	return PR_ERROR(cmd);
 
     } else {
 	char *mesg = "Unsupported protection type";
-	pr_response_add_err(R_504, "PROT %s unsupported", cmd->argv[1]);
-	gss_log("GSSAPI %s %s", mesg,cmd->argv[1]);
-	return ERROR(cmd);	    
+	pr_response_add_err(R_504, "PROT %s unsupported", argv[1]);
+	gss_log("GSSAPI %s %s", mesg,argv[1]);
+	return PR_ERROR(cmd);	    
 
     }
 
-    return HANDLED(cmd);
+    return PR_HANDLED(cmd);
 }
 
 
@@ -2089,33 +2092,35 @@ MODRET set_gssengine(cmd_rec *cmd) {
     c->argv[0] = pcalloc(c->pool, sizeof(unsigned char));
     *((unsigned char *) c->argv[0]) = bool;
 
-    return HANDLED(cmd);
+    return PR_HANDLED(cmd);
 }
 
 /* usage: GSSKeytab file */
 MODRET set_gsskeytab(cmd_rec *cmd) {
 
+    char **argv = (char **)cmd->argv;
     CHECK_ARGS(cmd, 1);
     CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL);
 
-    if (!file_exists(cmd->argv[1]))
+    if (!file_exists(argv[1]))
 	CONF_ERROR(cmd, "file does not exist");
 
-    if (*cmd->argv[1] != '/')
+    if (*argv[1] != '/')
 	CONF_ERROR(cmd, "parameter must be an absolute path");
 
-    add_config_param_str(cmd->argv[0], 1, cmd->argv[1]);
-    return HANDLED(cmd);
+    add_config_param_str(argv[0], 1, argv[1]);
+    return PR_HANDLED(cmd);
 }
 
 /* usage: GSSLog file */
 MODRET set_gsslog(cmd_rec *cmd) {
+    char **argv = (char **)cmd->argv;
 
     CHECK_ARGS(cmd, 1);
     CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL);
 
-    add_config_param_str(cmd->argv[0], 1, cmd->argv[1]);
-    return HANDLED(cmd);
+    add_config_param_str(argv[0], 1, argv[1]);
+    return PR_HANDLED(cmd);
 }
 
 /* usage: GSSOptions opt1 opt2 ... */
@@ -2123,46 +2128,47 @@ MODRET set_gssoptions(cmd_rec *cmd) {
     config_rec *c = NULL;
     register unsigned int i = 0;
     unsigned long opts = 0UL;
+    char **argv = (char **)cmd->argv;
 
     if (cmd->argc-1 == 0)
 	CONF_ERROR(cmd, "wrong number of parameters");
 
     CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL);
 
-    c = add_config_param(cmd->argv[0], 1, NULL);
+    c = add_config_param(argv[0], 1, NULL);
 
     for (i = 1; i < cmd->argc; i++) {
-       if (!strcasecmp(cmd->argv[i], "AllowCCC")) {
+       if (!strcasecmp(argv[i], "AllowCCC")) {
             opts |= GSS_OPT_ALLOW_CCC;
             pr_log_debug(DEBUG3, "GSSAPI GSSOption AllowCCC set");
-       } else if (!strcasecmp(cmd->argv[i], "AllowFWCCC")) {
+       } else if (!strcasecmp(argv[i], "AllowFWCCC")) {
             opts |= GSS_OPT_ALLOW_FW_CCC;
     	    pr_feat_add("FWCCC");
             pr_log_debug(DEBUG3, "GSSAPI GSSOption AllowFWCCC set");
-       } else if (!strcasecmp(cmd->argv[i], "AllowFWCCCOld")) {
+       } else if (!strcasecmp(argv[i], "AllowFWCCCOld")) {
             gss_flags |= GSS_SESS_FWCCC;
             pr_log_debug(DEBUG3, "GSSAPI GSSOption AllowFWCCCOld set");
-       } else if (!strcasecmp(cmd->argv[i], "AllowFWNAT")) {
+       } else if (!strcasecmp(argv[i], "AllowFWNAT")) {
             opts |= GSS_OPT_ALLOW_FW_NAT;
             pr_log_debug(DEBUG3, "GSSAPI GSSOption AllowFWNAT set");
-       } else if (!strcasecmp(cmd->argv[i], "NoChannelBinding")) {
+       } else if (!strcasecmp(argv[i], "NoChannelBinding")) {
             opts |= GSS_OPT_ALLOW_FW_NAT;
             pr_log_debug(DEBUG3, "GSSAPI GSSOption NoChannelBinding set");
-       } else if (!strcasecmp(cmd->argv[i], "RequireSequenceProtection")) {
+       } else if (!strcasecmp(argv[i], "RequireSequenceProtection")) {
             opts |= GSS_OPT_REQUIRE_SEQ_PROT;
             pr_log_debug(DEBUG3, "GSSAPI GSSOption RequireSequenceProtection set");
-       } else if (!strcasecmp(cmd->argv[i], "RequireReplayProtection")) {
+       } else if (!strcasecmp(argv[i], "RequireReplayProtection")) {
             opts |= GSS_OPT_REQUIRE_REP_PROT;
             pr_log_debug(DEBUG3, "GSSAPI GSSOption RequireReplayProtection set");
        } else
             CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, ": unknown GSSOption: '",
-                                cmd->argv[i], "'", NULL));
+                                argv[i], "'", NULL));
     }
 
     c->argv[0] = pcalloc(c->pool, sizeof(unsigned long));
     *((unsigned long *) c->argv[0]) = opts;
 
-    return HANDLED(cmd);
+    return PR_HANDLED(cmd);
 }
 
 /* usage: GSSRequired on|off|both|ctrl|control|data */
@@ -2204,7 +2210,7 @@ MODRET set_gssrequired(cmd_rec *cmd) {
     c->argv[1] = pcalloc(c->pool, sizeof(unsigned char));
     *((unsigned char *) c->argv[1]) = on_data;
 
-    return HANDLED(cmd);
+    return PR_HANDLED(cmd);
 }
 
 /* usage: GSSInet6 on|off|yes|no*/
@@ -2237,7 +2243,7 @@ MODRET set_gss_af_inet6(cmd_rec *cmd) {
     c->argv[0] = pcalloc(c->pool, sizeof(unsigned char));
     *((unsigned char *) c->argv[0]) = on_inet6;
 
-    return HANDLED(cmd);
+    return PR_HANDLED(cmd);
 }
 
 /* Event handlers
@@ -2265,11 +2271,11 @@ static void gss_postparse_ev(const void *event_data, void *user_data) {
                pr_log_pri(LOG_NOTICE, MOD_GSS_VERSION ": notice: unable to open GSSLog: %s",
                        strerror(errno));
 
-           else if (res == LOG_WRITEABLE_DIR)
+           else if (res == PR_LOG_WRITABLE_DIR)
                pr_log_pri(LOG_NOTICE, "notice: unable to open GSSLog: "
                        "parent directory is world writeable");
 
-           else if (res == LOG_SYMLINK)
+           else if (res == PR_LOG_SYMLINK)
                pr_log_pri(LOG_NOTICE, "notice: unable to open GSSLog: "
                        "cannot log to a symbolic link");
        }
@@ -2386,11 +2392,11 @@ static int gss_sess_init(void) {
 	    pr_log_pri(LOG_NOTICE, MOD_GSS_VERSION ": notice: unable to open GSSLog: %s",
 		    strerror(errno));
 
-	else if (res == LOG_WRITEABLE_DIR)
+	else if (res == PR_LOG_WRITABLE_DIR)
 	    pr_log_pri(LOG_NOTICE, "notice: unable to open GSSLog: "
 		    "parent directory is world writeable");
 
-	else if (res == LOG_SYMLINK)
+	else if (res == PR_LOG_SYMLINK)
 	    pr_log_pri(LOG_NOTICE, "notice: unable to open GSSLog: "
 		    "cannot log to a symbolic link");
     }
@@ -2621,7 +2627,7 @@ static int gss_dispatch(char *buf)
 
     *((char **) push_array(tarr)) = NULL;
 
-    newcmd->argv = (char **) tarr->elts;
+    newcmd->argv = (void **) tarr->elts;
     /* This table will not contain that many entries, so a low number
      * of chains should suffice.
      */


### PR DESCRIPTION
  version 1.3.6.

the summary of changes is as follows:

trivial changes (but apply them with some caution):
	s/ERROR/PR_ERROR
	s/DECLINED/PR_DECLINED
	s/HANDLED/PR_HANDLED
	s/LOG_SYMLINK/PR_LOG_SYMLINK
	s/LOG_WRITEABLE_DIR/LOG_WRITABLE_DIR

slightly more complex change:
	we need to deal with change of cmd_struc::argv member.
	it got changed from char ** to void ** in ProFTPD 1.3.6.

	everywhere where current code deals with cmd->argv[x], patch
	introduces a local variable 'char **argv = (char **)cmd->argv;'
	and delivers apropriate change e.g.:

		- cmd->argv[0] = ....
		+ argv[0] = ....

with all that in place I can compile mod_gss with ProFTPD 1.3.6