### PR TITLE
- fixes mod_gss on sparc64 (integer promotion)

### DIFF
--- a/mod_gss/mod_gss/mod_gss.c.in
+++ b/mod_gss/mod_gss/mod_gss.c.in
@@ -88,7 +88,7 @@ static pool *fmt_pool = NULL;
 static char *gss_format_cb(pool *,const char *fmt, ...);
 static void gss_closelog(void);
 static char *radix_error(int e);
-static int  radix_encode(unsigned char inbuf[], unsigned char outbuf[], int *len, int decode);
+static int  radix_encode(unsigned char inbuf[], unsigned char outbuf[], size_t *len, int decode);
 static void reply_gss_error(char *code, OM_uint32 maj_stat, OM_uint32 min_stat, char *s);
 static void log_gss_error(OM_uint32 maj_stat, OM_uint32 min_stat, char *s);
 static ssize_t looping_read(int fd, register char *buf,register int len);
@@ -1196,7 +1196,7 @@ MODRET gss_dec(cmd_rec *cmd) {
     xmit_buf.length=strlen(cmd->arg)+1;
     /* protected string <= unprotected string */
     xmit_buf.value=pcalloc(cmd->pool,strlen(cmd->arg)+1);
-    if ((error = radix_encode((unsigned char*)cmd->arg, xmit_buf.value, (int *)&xmit_buf.length, 1)) != 0 ) {
+    if ((error = radix_encode((unsigned char*)cmd->arg, xmit_buf.value, &xmit_buf.length, 1)) != 0 ) {
 	pr_response_add_err(R_501, "Couldn't base 64 decode argument to %s command (%s)",
 		session.sp_flags & SP_ENC ? "ENC" : 
                 session.sp_flags & SP_MIC ? "MIC" : "", radix_error(error));
@@ -1566,7 +1566,7 @@ MODRET gss_adat(cmd_rec *cmd) {
     */
 
     tok.value=pcalloc(cmd->tmp_pool,strlen(cmd->arg));
-    if ((error = radix_encode((unsigned char*)cmd->arg, tok.value , (int *)&tok.length, 1)) !=0  ) {
+    if ((error = radix_encode((unsigned char*)cmd->arg, tok.value , &tok.length, 1)) !=0  ) {
 	pr_response_add_err(R_501, "Couldn't decode ADAT (%s)",radix_error(error)); 
 	gss_log("GSSAPI Could not decode ADAT (%s)",radix_error(error));
 	return ERROR(cmd);
@@ -1646,7 +1646,7 @@ MODRET gss_adat(cmd_rec *cmd) {
 
     if (out_tok.length) {
         gbuf = pcalloc(cmd->tmp_pool,out_tok.length*4+1);
-	if ( (error = radix_encode((unsigned char*)out_tok.value, (unsigned char*)gbuf, (int *)&out_tok.length, 0)) != 0 ) {
+	if ( (error = radix_encode((unsigned char*)out_tok.value, (unsigned char*)gbuf, &out_tok.length, 0)) != 0 ) {
 	    pr_response_add_err(R_535,"Couldn't encode ADAT reply (%s)",
 			     radix_error(error));
 	    gss_log("GSSAPI Could not encode ADAT reply (%s)",radix_error(error));
@@ -2570,7 +2570,7 @@ static char *gss_format_cb(pool *pool, const char *fmt, ...)
     } 
     /* protected reply <= 4*unprotected reply */
     reply=pcalloc(pool, gss_out_buf.length*4+1);
-    if ((error = radix_encode(gss_out_buf.value, (unsigned char*)reply, (int *)&gss_out_buf.length, 0)) != 0 ) {
+    if ((error = radix_encode(gss_out_buf.value, (unsigned char*)reply, &gss_out_buf.length, 0)) != 0 ) {
 	gss_log("Couldn't encode reply (%s)", radix_error(error));
 	gss_release_buffer(&min_stat, &gss_out_buf);
         return pstrdup(pool ,buf);
@@ -2926,7 +2926,7 @@ static ssize_t looping_read(int fd, register char *buf, int len)
    Case must not be ignored when reading commands and replies containing
    base 64 encodings.
  */
-static int radix_encode(unsigned char inbuf[], unsigned char outbuf[], int *len, int decode)
+static int radix_encode(unsigned char inbuf[], unsigned char outbuf[], size_t *len, int decode)
 {
     int           i,j,D=0;
     char          *p;


### PR DESCRIPTION
The bug prevents ftp clients, which use GSSAPI to authenticate. It is caused by
so called _integer _promotion_  ([sizeof () is not int anymore](https://docs.oracle.com/cd/E19455-01/806-0477/6j9r2e2av/index.html). Porting 32-bit sparc applications to 64-bit sparc requires caution. The issue can be illustrated on sample program here:
```
/*
 * Integer promotion on sparc32 vs sparc64 is not compiler bug.
 *
 * compile 32-bit version, run it and watch for output:
 *      bash-4.4$ gcc -m32 main.c -o main
 *      bash-4.4$ ./main 
 *      -17958194 (0xfeedface) -> 1073885187 (0x40023003)
 * the output is something one might expect to see.
 *
 * compile it as 64-bit application and repeat test:
 *      bash-4.4$ gcc -m64 main.c -o main
 *      -17958194 (0xfeedface) -> -17958194 (0xfeedface)
* The numbers are same!!!
 *
 * do the same on intel (32bit, 64bit), and you'll see the output
 * is always same regardless the CPU bits...
 *
 * remember:    int is not size_t
 */
#include <stdio.h>
#include <stdint.h>

static void
mask(int *n)
{
        *n ^= 0xbeefcacd;
}

int
main(int argc, char * const argv[])
{
        size_t  number = 0xfeedface;

        printf("%d (0x%x) -> ", number, number);
        mask((int *)&number);
        printf("%d (0x%x)\n", number, number);
        return (0);
}
```

the `(size_t *)` vs. `(int *)` causes mod_gss to corrupt kerberos data during base64 decoding. this makes kerberos authentication process to fail.